### PR TITLE
Used pattern matching to match subcommands

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,6 +1,6 @@
 use crate::util;
 
-use clap::{Arg, App, SubCommand, ArgMatches};
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use std::convert::AsRef;
 use strum_macros::{AsRefStr, EnumString};
 
@@ -30,93 +30,108 @@ pub enum Parameters {
 }
 
 pub fn parse_arguments() -> ArgMatches<'static> {
+    let resource_id_arg = Arg::with_name(Parameters::id.as_ref())
+        .required(true)
+        .help("The unique id of the resource.");
 
-let resource_id_arg = Arg::with_name(Parameters::id.as_ref())
-    .required(true)
-    .help("The unique id of the resource.");
+    let url_arg = Arg::with_name(Parameters::url.as_ref())
+        .long(Parameters::url.as_ref())
+        .takes_value(true)
+        .help("The url of the registry endpoint");
 
-let url_arg = Arg::with_name(Parameters::url.as_ref())
-    .long(Parameters::url.as_ref())
-    .takes_value(true)
-    .help("The url of the registry endpoint");
+    let app_id_arg = Arg::with_name(Resources::app.as_ref())
+        .required(true)
+        .long(Resources::app.as_ref())
+        .takes_value(true)
+        .help("The app owning the device.");
 
-let app_id_arg = Arg::with_name(Resources::app.as_ref())
-    .long(Resources::app.as_ref())
-    .takes_value(true)
-    .help("The app owning the device.");
+    let data_arg = Arg::with_name(Parameters::data.as_ref())
+        .short("d")
+        .long(Parameters::data.as_ref())
+        .takes_value(true)
+        .help("The data for the resource.");
 
-let data_arg = Arg::with_name(Parameters::data.as_ref())
-    .short("d")
-    .long(Parameters::data.as_ref())
-    .takes_value(true)
-    .help("The data for the resource.");
+    let config_file_arg = Arg::with_name(Parameters::config.as_ref())
+        .long(Parameters::config.as_ref())
+        .takes_value(true)
+        .conflicts_with(Parameters::url.as_ref())
+        .help("Path to the drgconfig file. Defaults to ~/.drgconfig");
 
-let config_file_arg = Arg::with_name(Parameters::config.as_ref())
-    .long(Parameters::config.as_ref())
-    .takes_value(true)
-    .conflicts_with(Parameters::url.as_ref())
-    .help("Path to the drgconfig file. Defaults to ~/.drgconfig");
-
-
-App::new("Drogue Command Line Tool")
-    .version(util::VERSION)
-    .author("Jb Trystram <jbtrystram@redhat.com>")
-    .about("Allows to manage drogue apps and devices in a drogue-cloud instance")
-    .arg(config_file_arg)
-    .arg(url_arg)
-    .subcommand(SubCommand::with_name(Verbs::create.as_ref())
-            .alias("add")
-            .about("create a resource in the drogue-cloud registry")
-            .subcommand(
-                SubCommand::with_name(Resources::device.as_ref())
-                    .about("create a device.")
-                    .arg(resource_id_arg.clone())
-                    .arg(app_id_arg.clone())
-                    .arg(data_arg.clone())
-            ).subcommand(SubCommand::with_name(Resources::app.as_ref())
-                .about("create an app.")
-                .arg(resource_id_arg.clone())
-                .arg(data_arg.clone())
-            )
-    ).subcommand(
-        SubCommand::with_name(Verbs::delete.as_ref())
-            .alias("remove")
-            .about("delete a resource in the drogue-cloud registry")
-            .subcommand(
-                SubCommand::with_name(Resources::device.as_ref())
-                    .about("delete a device.")
-                    .arg(resource_id_arg.clone())
-                    .arg(app_id_arg.clone())
-            ).subcommand(SubCommand::with_name(Resources::app.as_ref())
-            .about("create an app.")
-            .arg(resource_id_arg.clone())
-            )
-    ).subcommand(
-    SubCommand::with_name(Verbs::get.as_ref())
-        .about("Read a resource from the drogue-cloud registry")
+    App::new("Drogue Command Line Tool")
+        .version(util::VERSION)
+        .author("Jb Trystram <jbtrystram@redhat.com>")
+        .about("Allows to manage drogue apps and devices in a drogue-cloud instance")
+        .arg(config_file_arg)
+        .arg(url_arg)
+        .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
-            SubCommand::with_name(Resources::device.as_ref())
-                .about("Retrieve a device data.")
-                .arg(resource_id_arg.clone())
-                .arg(app_id_arg.clone())
-        ).subcommand(SubCommand::with_name(Resources::app.as_ref())
-        .about("retrieve an app data.")
-        .arg(resource_id_arg.clone())
+            SubCommand::with_name(Verbs::create.as_ref())
+                .alias("add")
+                .about("create a resource in the drogue-cloud registry")
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .subcommand(
+                    SubCommand::with_name(Resources::device.as_ref())
+                        .about("create a device.")
+                        .arg(resource_id_arg.clone())
+                        .arg(app_id_arg.clone())
+                        .arg(data_arg.clone()),
+                )
+                .subcommand(
+                    SubCommand::with_name(Resources::app.as_ref())
+                        .about("create an app.")
+                        .arg(resource_id_arg.clone())
+                        .arg(data_arg.clone()),
+                ),
         )
-    ).subcommand(
-    SubCommand::with_name(Verbs::edit.as_ref())
-        .about("Edit a resource from the drogue-cloud registry")
         .subcommand(
-            SubCommand::with_name(Resources::device.as_ref())
-                .about("Edit a device data.")
-                .arg(resource_id_arg.clone())
-                .arg(app_id_arg.clone())
-        ).subcommand(SubCommand::with_name(Resources::app.as_ref())
-        .about("Edit an app data.")
-        .arg(resource_id_arg.clone())
+            SubCommand::with_name(Verbs::delete.as_ref())
+                .alias("remove")
+                .about("delete a resource in the drogue-cloud registry")
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .subcommand(
+                    SubCommand::with_name(Resources::device.as_ref())
+                        .about("delete a device.")
+                        .arg(resource_id_arg.clone())
+                        .arg(app_id_arg.clone()),
+                )
+                .subcommand(
+                    SubCommand::with_name(Resources::app.as_ref())
+                        .about("create an app.")
+                        .arg(resource_id_arg.clone()),
+                ),
         )
-    ).subcommand(
-            SubCommand::with_name("version")
-                .about("Print version information.")
-    ).get_matches()
+        .subcommand(
+            SubCommand::with_name(Verbs::get.as_ref())
+                .about("Read a resource from the drogue-cloud registry")
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .subcommand(
+                    SubCommand::with_name(Resources::device.as_ref())
+                        .about("Retrieve a device data.")
+                        .arg(resource_id_arg.clone())
+                        .arg(app_id_arg.clone()),
+                )
+                .subcommand(
+                    SubCommand::with_name(Resources::app.as_ref())
+                        .about("retrieve an app data.")
+                        .arg(resource_id_arg.clone()),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name(Verbs::edit.as_ref())
+                .about("Edit a resource from the drogue-cloud registry")
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .subcommand(
+                    SubCommand::with_name(Resources::device.as_ref())
+                        .about("Edit a device data.")
+                        .arg(resource_id_arg.clone())
+                        .arg(app_id_arg.clone()),
+                )
+                .subcommand(
+                    SubCommand::with_name(Resources::app.as_ref())
+                        .about("Edit an app data.")
+                        .arg(resource_id_arg.clone()),
+                ),
+        )
+        .subcommand(SubCommand::with_name("version").about("Print version information."))
+        .get_matches()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,6 @@
-use anyhow::{Result};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::{
-    env::var,
-    fs::File,
-};
-
+use std::{env::var, fs::File};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
@@ -13,12 +9,9 @@ pub struct Config {
 }
 
 pub fn load_config_file(path: Option<&str>) -> Result<Config> {
-
     let path = match path {
         Some(p) => p.to_string(),
-        None => {
-            var("DRGCFG").unwrap_or(format!("{}/.drgconfig.json", var("HOME")?))
-        }
+        None => var("DRGCFG").unwrap_or(format!("{}/.drgconfig.json", var("HOME")?)),
     };
     //todo verbose option
     println!("Loading config file: {}", path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ mod config;
 mod devices;
 mod util;
 
-use arguments::{Parameters, Verbs, Resources};
+use arguments::{Parameters, Resources, Verbs};
 
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use std::str::FromStr;
 
 type AppId = str;
@@ -18,14 +18,6 @@ fn main() -> Result<()> {
     if matches.is_present("version") {
         util::print_version();
     }
-
-    // TODO : unsafe unwraps !!!!
-    let (cmd_name, cmd) = matches.subcommand();
-    //deserialize the command into enum to take advantage of rust exhaustive match
-    let verb = Verbs::from_str(cmd_name).unwrap();
-    let (sub_cmd_name, sub_cmd) = cmd.unwrap().subcommand();
-    let resource = Resources::from_str(sub_cmd_name).unwrap();
-    let id = sub_cmd.unwrap().value_of(Parameters::id).unwrap();
 
     let url;
     //todo default app is not used
@@ -41,41 +33,71 @@ fn main() -> Result<()> {
         _default_app = conf.default_app;
     }
 
-    match verb {
-        Verbs::create => {
-            let data = util::json_parse(sub_cmd.unwrap().value_of(Parameters::data))?;
-            match resource {
-                Resources::app => apps::create(&url, id, data)?,
-                Resources::device => {
-                    let app_id = sub_cmd.unwrap().value_of(Resources::app).unwrap();
-                    devices::create(&url, id, data, app_id)?
+    match matches.subcommand() {
+        (cmd_name, sub_cmd) => {
+            let verb = Verbs::from_str(cmd_name);
+            let cmd = sub_cmd.unwrap();
+
+            match verb? {
+                Verbs::create => match cmd.subcommand() {
+                    (res, command) => {
+                        let data = util::json_parse(command.unwrap().value_of(Parameters::data))?;
+                        let id = command.unwrap().value_of(Parameters::id).unwrap();
+
+                        let resource = Resources::from_str(res);
+
+                        match resource? {
+                            Resources::app => apps::create(&url, id, data)?,
+                            Resources::device => {
+                                let app_id = command.unwrap().value_of(Resources::app).unwrap();
+                                devices::create(&url, id, data, app_id)?
+                            }
+                        }
+                    }
                 },
-            }
-        }
-        Verbs::delete => {
-            match resource {
-                Resources::app => apps::delete(&url, id)?,
-                Resources::device => {
-                    let app_id = sub_cmd.unwrap().value_of(Resources::app).unwrap();
-                    devices::delete(&url, app_id, id)?
+                Verbs::delete => match cmd.subcommand() {
+                    (res, command) => {
+                        let id = command.unwrap().value_of(Parameters::id).unwrap();
+                        let resource = Resources::from_str(res);
+
+                        match resource? {
+                            Resources::app => apps::delete(&url, id)?,
+                            Resources::device => {
+                                let app_id = command.unwrap().value_of(Resources::app).unwrap();
+                                devices::delete(&url, app_id, id)?
+                            }
+                        }
+                    }
                 },
-            }
-        }
-        Verbs::edit => {
-            match resource {
-                Resources::app => apps::edit(&url, id),
-                Resources::device => {
-                    let app_id = sub_cmd.unwrap().value_of(Resources::app).unwrap();
-                    devices::edit(&url, app_id, id)
+                Verbs::edit => match cmd.subcommand() {
+                    (res, command) => {
+                        let id = command.unwrap().value_of(Parameters::id).unwrap();
+
+                        let resource = Resources::from_str(res);
+
+                        match resource? {
+                            Resources::app => apps::edit(&url, id),
+                            Resources::device => {
+                                let app_id = command.unwrap().value_of(Resources::app).unwrap();
+                                devices::edit(&url, app_id, id)
+                            }
+                        }
+                    }
                 },
-            }
-        }
-        Verbs::get => {
-            match resource {
-                Resources::app => apps::read(&url, id)?,
-                Resources::device => {
-                    let app_id = sub_cmd.unwrap().value_of(Resources::app).unwrap();
-                    devices::read(&url, app_id, id)?
+                Verbs::get => match cmd.subcommand() {
+                    (res, command) => {
+                        let id = command.unwrap().value_of(Parameters::id).unwrap();
+
+                        let resource = Resources::from_str(res);
+
+                        match resource? {
+                            Resources::app => apps::read(&url, id)?,
+                            Resources::device => {
+                                let app_id = command.unwrap().value_of(Resources::app).unwrap();
+                                devices::read(&url, app_id, id)?
+                            }
+                        }
+                    }
                 },
             }
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,72 +1,65 @@
-use crate::{Verbs};
-use anyhow::{Result, Context};
+use crate::Verbs;
+use anyhow::{Context, Result};
 use reqwest::blocking::Response;
 use reqwest::{StatusCode, Url};
-use serde_json::{Value, from_str};
+use serde_json::{from_str, Value};
+use std::process::exit;
 use std::{
     env::var,
-    io::{Write, Read},
+    io::{Read, Write},
     process::Command,
 };
 use tempfile::NamedTempFile;
-use std::process::exit;
 
 pub const VERSION: &str = "0.1-beta1";
 pub const COMPATIBLE_DROGUE_VERSION: &str = "0.3.0";
 
 pub fn print_result(r: Response, resource_name: String, op: Verbs) {
     match op {
-        Verbs::create => {
-            match r.status() {
-                StatusCode::CREATED => println!("{} created.", resource_name),
-                r => println!("Error : {}", r),
-            }
-        }, Verbs::delete => {
-            match r.status() {
-                StatusCode::NO_CONTENT => println!("{} deleted.", resource_name),
-                r => println!("Error : {}", r),
-            }
-        }, Verbs::get => {
-            match r.status() {
-                StatusCode::OK => println!("{}", r.text().expect("Empty response")),
-                r => println!("Error : {}", r),
-            }
-        }, Verbs::edit => {
-            match r.status() {
-                StatusCode::NO_CONTENT => println!("{} edited.", resource_name),
-                r => println!("Error : {}", r),
-            }
-        }
+        Verbs::create => match r.status() {
+            StatusCode::CREATED => println!("{} created.", resource_name),
+            r => println!("Error : {}", r),
+        },
+        Verbs::delete => match r.status() {
+            StatusCode::NO_CONTENT => println!("{} deleted.", resource_name),
+            r => println!("Error : {}", r),
+        },
+        Verbs::get => match r.status() {
+            StatusCode::OK => println!("{}", r.text().expect("Empty response")),
+            r => println!("Error : {}", r),
+        },
+        Verbs::edit => match r.status() {
+            StatusCode::NO_CONTENT => println!("{} edited.", resource_name),
+            r => println!("Error : {}", r),
+        },
     }
-
 }
-
-
 
 pub fn url_validation(url: Option<&str>) -> Result<Url> {
     Url::parse(url.unwrap()).context(format!("URL args: \'{}\' is not valid", url.unwrap()))
 }
 
 pub fn json_parse(data: Option<&str>) -> Result<Value> {
-    from_str(data.unwrap_or("{}")).context(format!("Can't parse data args: \'{}\' into json", data.unwrap()))
+    from_str(data.unwrap_or("{}")).context(format!(
+        "Can't parse data args: \'{}\' into json",
+        data.unwrap_or("")
+    ))
 }
 
-
 pub fn editor(original: String) -> Result<Value> {
-
     //TODO : that would not work on windows !
     let editor = var("EDITOR").unwrap_or("vi".to_string());
     let file = NamedTempFile::new()?;
     //the handler needs to be kept to reopen the file later.
-    let mut file2= file.reopen()?;
+    let mut file2 = file.reopen()?;
 
     // Write the original data to the file.
     file.as_file().write_all(original.as_bytes())?;
 
     Command::new(editor)
-         .arg(file.path())
-         .status()
-         .expect("Could not open current data in editor.");
+        .arg(file.path())
+        .status()
+        .expect("Could not open current data in editor.");
 
     // Read the data using the second handle.
     let mut buf = String::new();
@@ -76,7 +69,7 @@ pub fn editor(original: String) -> Result<Value> {
 }
 
 pub fn print_version() {
-   //todo add git hash and build date to version output ?
+    //todo add git hash and build date to version output ?
 
     println!("Client Version: {}", VERSION);
     println!("Compatible Server Version: {}", COMPATIBLE_DROGUE_VERSION);


### PR DESCRIPTION
Fixes #3 

- The panic caused by unwraps is handling using pattern matching. 
- `required(true)` is added to `app_id_arg` to delegate error handling to clap.
